### PR TITLE
fix indentation

### DIFF
--- a/resources_pages/installation_instructions.md
+++ b/resources_pages/installation_instructions.md
@@ -83,12 +83,10 @@ For this program we are using __Python 3__, not __Python 2__, so please choose t
 1. Head to https://www.continuum.io/downloads and download the Anaconda version for Mac OS with Python 3.5.
 2. Follow the instructions on that page to run the installer.
 
-  If you already have installed Anaconda at some point in the past, you can update to the latest Anaconda version by updating conda, then Anaconda in terminal as follows:
+    If you already have installed Anaconda at some point in the past, you can update to the latest Anaconda version by updating conda, then Anaconda in terminal as follows:
   
-  ```
-  conda update conda
-  conda update anaconda    
-  ``` 
+        conda update conda
+        conda update anaconda    
 
 
 3. Test out the Jupyter notebook: open a Terminal window, and type `jupyter notebook`. Or use the Anaconda Launcher which might have been deposited on your desktop. A new browser window should pop up.


### PR DESCRIPTION
beautiful jekyll uses by default the kramdown parser for markdown. It's not exactly identical to the github-flavoured markdown. You can change the markdown flavour in the config file: https://github.com/UBC-MDS/UBC-MDS.github.io/blob/master/_config.yml#L76

According to [this issue](https://github.com/gettalong/kramdown/issues/123), the correct way to have an indented code block inside a list is to indent the code block with 8 spaces (4 spaces for being inside a list, and 4 spaces for being a code block). The rest of the text inside that list needs to be indented by 4 spaces (not 2 spaces as was done before).  I haven't tested it, but this should fix it hopefully
