### PR TITLE
Mac os install 2020

### DIFF
--- a/resources_pages/install_ds_stack_mac.md
+++ b/resources_pages/install_ds_stack_mac.md
@@ -5,7 +5,7 @@ subtitle: MDS software stack install instructions for macOS
 ---
 These instructions will walk you through installing the required Data Science software stack for the UBC Master of Data Science program. Before starting, ensure that your laptop meets our program requirements:
 
-- runs one of the following operating systems: macOS 10.15.X (Catalina) or later, Ubuntu 20.04 or later, Windows 10 Professional, Enterprise or Education; version 2004 or later. Please note that Windows 10 Home is not sufficient as not all the software required for the program can be installed on that OS.
+- runs one of the following operating systems: macOS 10.15.X (Catalina), Ubuntu 20.04, Windows 10 Professional, Enterprise or Education; version 2004. *Note that Windows 10 Home is not sufficient as not all the software required for the program can be installed on that OS. Also note that when installing Ubuntu, checking the box "Install third party..." will (among other things) install proprietary drivers, which can be helpful for wifi and graphics cards.*
 - can connect to networks via a wireless connection
 - has at least 50 GB disk space available
 - has at least 8 GB of RAM
@@ -14,10 +14,11 @@ These instructions will walk you through installing the required Data Science so
 - uses English as the default language
 - student user has full administrative access to the computer
 
-**Students' whose laptops do not meet the requirements specified above will not be able to receive techinical assistance from the MDS team in troubleshooting installation issues.**
+**Students' whose laptops do not meet the requirements specified above will not be able to receive technical assistance from the MDS team in troubleshooting installation issues.**
 
 ## Table of Contents
-- [Google Chrome browser](#chrome-browswer)
+
+- [Google Chrome browser](#chrome-browser)
 - [LastPass password manager](#lastpass-password-manager)
 - [Slack](#slack)
 - [Bash shell](#bash-shell)
@@ -34,28 +35,33 @@ These instructions will walk you through installing the required Data Science so
 - [Visual Studio Code Extensions](#visual-studio-code-extensions)
 
 ## Google Chrome browser
+
 In MDS we will be using many tools that work most reliably on the Google Chrome browser (including our online quiz software). To install it, go to [https://www.google.com/chrome/](https://www.google.com/chrome/), click on "Download Chrome" and follow the instructions on the website to finish the installation.
 
 ## LastPass password manager
+
 In MDS we share credentials via the password manager LastPass. This can also be useful for helping keep secure passwords and efficient authentication. Sign up for a free LastPass account here: [https://lastpass.com/create-account.php](https://lastpass.com/create-account.php). We also recommend installing the LastPass Chrome Extension available here: [https://chrome.google.com/webstore/detail/lastpass-free-password-ma/hdokiejnpimakedhajhdlcegeplioahd](https://chrome.google.com/webstore/detail/lastpass-free-password-ma/hdokiejnpimakedhajhdlcegeplioahd).
 
 ## Slack
-For our MDS courses and program annoucements, correspondance and course forums we use the communcation tool Slack. Slack can be accessed via the web browser, however we strongly recommend installing the Slack App. The Slack app can be installed from the Mac App Store, or from the Slack website. Installation instructions from the Slack website install method are here: [https://slack.com/intl/en-ca/help/articles/207677868-Download-Slack-for-Mac](https://slack.com/intl/en-ca/help/articles/207677868-Download-Slack-for-Mac)
+
+For our MDS courses and program announcements, correspondence and course forums we use the communication tool Slack. Slack can be accessed via the web browser, however we strongly recommend installing the Slack App. The Slack app can be installed from the Mac App Store, or from the Slack website. Installation instructions from the Slack website install method are here: [https://slack.com/intl/en-ca/help/articles/207677868-Download-Slack-for-Mac](https://slack.com/intl/en-ca/help/articles/207677868-Download-Slack-for-Mac)
 
 ## Bash shell
-Apple recently changed the Mac default shell in the Terminal to Zsh, however, we aim to teach with the same shell across all three operating systems we support, which is the Bash shell. Thus, we ask that you change the default shell in your Terminal to Bash by opening the Terminal ([how to video](https://youtu.be/5AJbWEWwnbY)) and typing: 
+
+Apple recently changed the Mac default shell in the Terminal to Zsh, however, we aim to teach with the same shell across all three operating systems we support, which is the Bash shell. Thus, we ask that you change the default shell in your Terminal to Bash by opening the Terminal ([how to video](https://youtu.be/5AJbWEWwnbY)) and typing:
 
 ```
 chsh -s /bin/bash
 ```
 
-You will have to quit all instances of open Terminals and then restart the Terminal for this to take effect. 
+You will have to quit all instances of open Terminals and then restart the Terminal for this to take effect.
 
 ## Visual Studio Code
 
 ### Installing
 
-We need a powerfull but lightwight text editor, as well as a full-blown Python IDE for more complex analysis projects, the open-source text editor Visual Studio Code (VS Code) can serve both of these purposes for us. You can download VS Code at [https://code.visualstudio.com/download](https://code.visualstudio.com/download). Follow the installation instructions here: [https://code.visualstudio.com/docs/setup/mac](https://code.visualstudio.com/docs/setup/mac). **Be sure to follow the "[Launching from the command line](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line)" instructions as well.**
+The open-source text editor Visual Studio Code (VS Code) is both a powerful text editor and a full-blown Python IDE, which we will use for more complex analysis. You can install VS Code either via the [Snap store/Ubuntu software app through this link](https://snapcraft.io/code) or via the downloadable deb-file from the VS code website [https://code.visualstudio.com/download](https://code.visualstudio.com/download). The getting started instructions are here: [https://code.visualstudio.com/docs/setup/mac](https://code.visualstudio.com/docs/setup/mac).
+**Be sure to follow the ["Launching from the command line"](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line) instructions as well.**
 
 You can test that VS code is installed and can be opened from Terminal by restarting terminal and typing the following command:
 
@@ -64,25 +70,26 @@ code --version
 ```
 
 you should see something like this if you were successful:
+
 ```
 1.45.1
 5763d909d5f12fe19f215cbfdd29a91c0fa9208a
 x64
 ```
 
-> Note: If you get an error message such as `-bash: code: command not found`, but you can see the VS Code application has been installed, then something went wrong with setting up the lauch from the command line. Try following [these](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line) instrutions again, in particular you might want to try the described manual method of adding VS Code to your path.
+> Note: If you get an error message such as `-bash: code: command not found`, but you can see the VS Code application has been installed, then something went wrong with setting up the launch from the command line. Try following [these instructions](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line) again, in particular you might want to try the described manual method of adding VS Code to your path.
 
 ## GitHub
 
-In MDS we will use [GitHub.com](https://github.com/) as well as an Enterprise version of GitHub hosted here at UBC, [GitHub.ubc.ca](https://github.ubc.ca). Please follow the set-up instructions for both below.
+In MDS we will use the publicly available [GitHub.com](https://github.com/) as well as an Enterprise version of GitHub hosted here at UBC, [GitHub.ubc.ca](https://github.ubc.ca). Please follow the set-up instructions for both below.
 
 #### GitHub.com
-If you do not yet have one, sign up for a free account at [GitHub.com](https://github.com/).
+
+Sign up for a free account at [GitHub.com](https://github.com/) if you don't have one already.
 
 #### GitHub.ubc.ca
-For us to add you to the MDS organization on [Github.ubc.ca](https://github.ubc.ca) we need you to login using your CWL:
 
-visit [Github.ubc.ca](https://github.ubc.ca) to do this.
+To add you to the MDS organization on [Github.ubc.ca](https://github.ubc.ca) we need you to login to [Github.ubc.ca](https://github.ubc.ca) using your CWL credentials.
 
 This step is required for
 - being able to store your work
@@ -91,17 +98,20 @@ This step is required for
 
 ## Git
 
-We will be using the command line version of Git as well as Git through RStudio and JupyterLab. There are some new Git commands that we will use that are only available as of Git 2.23 (or newer), thus to get this newest version we will ask you to install Xcode command line tools (not all of Xcode), which includes Git.
+We will be using the command line version of Git as well as Git through RStudio and Jupyter lab. Some of the Git commands we will use are only available since Git 2.23, so if you're Git is older than this version, we ask you to update it using the Xcode command line tools (not all of Xcode), which includes Git.
 
 Open Terminal and type the following command to install Xcode command line tools:
+
 ```
 xcode-select --install
 ```
 
 After installation, in terminal type the following to ask for the version:
+
 ```
 git --version
 ```
+
 you should see something like this (does not have to be the exact same version) if you were successful:
 
 ```
@@ -110,7 +120,7 @@ git version 2.24.2 (Apple Git-127)
 
 > Note: If you run into trouble, please see that Install Git > Mac OS section from [Happy Git and GitHub for the useR](http://happygitwithr.com/install-git.html#mac-os) for additional help or strategies for Git installation.
 
-Next, we need to configure Git by telling it who you are, your email and setting the default text editor to VS Code. To do this type the following into the terminal (replacing Jane Doe and janedoe@example.com, with your name and email, respectively):
+Next, we need to configure Git by telling it who you are, your email, and setting the default text editor to VS Code. To do this type the following into the terminal (replacing Jane Doe and janedoe@example.com, with your name and email, respectively):
 
 ```
 git config --global user.name "Jane Doe"
@@ -118,18 +128,17 @@ git config --global user.email janedoe@example.com
 git config --global core.editor code
 ```
 
-> Note: to ensure you haven't made a typo in any of the above, you can view your global Git configurations by typing: `git config --list --global --show-origin`.
-
+> Note: to ensure that you haven't made a typo in any of the above, you can view your global Git configurations by either opening the configuration file in a text editor (e.g. via the command `code ~/.gitconfig`) or by typing `git config --list --global`.
 
 ## Python
 
-We will be using Python for a large part of the program, and `conda` as our Python package manager. Thus to install Python and the `conda` package manager, we will install [Miniconda](https://docs.conda.io/en/latest/miniconda.html). We recommend installing the [Miniconda MacOSX 64-bit pkg install for Python **3.7**](https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.pkg).
+We will be using Python for a large part of the program, and `conda` as our Python package manager. To install Python and the `conda` package manager, we will use the [Miniconda platform (read more here)](https://docs.conda.io/en/latest/miniconda.html), for which the [Miniconda MacOSX 64-bit pkg install for Python **3.7**](https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.pkg).
 
-After installation, in terminal type the following to ask for the version of conda:
+After installation, restart the terminal. If the installation was successful, you will see `(base)` prepending to your prompt string. To confirm that `conda` is working, you can ask it which version was installed:
 ```
 conda --version
 ```
-you should see something like this if you were successful at installing conda (a Python package manager):
+which should return something like this:
 
 ```
 conda 4.8.2
@@ -137,31 +146,40 @@ conda 4.8.2
 
 > Note: If you see `zsh: command not found: conda`, see the section on [Bash](#bash-shell) above to set your default Terminal shell to Bash as opposed to Zsh.
 
-After installation, in terminal type the following to ask for the version of Python:
+Next, type the following to ask for the version of Python:
 ```
 python --version
 ```
-you should see something like this if you were successful at installing Python:
+which should return something like this:
 
 ```
-Python 3.7.6
+Python 3.7.7
 ```
 
 > Note: If instead you see `Python 2.7.X` you installed the wrong version. Uninstall the Miniconda you just installed (which usually lives in the `/opt` directory), and try the installation again, selecting **Python 3.7**.
 
 ## Essential Python packages
 
-We also prefer to use packages on the conda-forge channel, so we set that to the default by typing the following in the terminal:
+`conda` installs Python packages from different online repositories which are called "channels".
+A package needs to go through thorough testing before it is included in the default channel,
+which is good for stability,
+but also means that new versions will be delayed and fewer packages are available overall.
+There is a community-driven effort called the [conda-forge (read more here)](https://conda-forge.org/),
+which provides more up to date packages
+To enable us to access the most up to date version of the Python packages we are going to use,
+we will add the more up to date  channel,
+To add the conda-forge channel by typing the following in the terminal:
+
 
 ```
 conda config --add channels conda-forge
 
 ```
 
-Thus, to install other pacakges individually, we can now use the following: conda install <package-name>. We will install the key packages needed for the start of our program now:
+To install packages individually, we can now use the following command: `conda install <package-name>`. Let's install the key packages needed for the start of our program:
 
 ```
-conda install --yes \
+conda install \
  jupyterlab=2.* \
  numpy=1.* \
  pandas=1.* \
@@ -169,22 +187,32 @@ conda install --yes \
  black=19.*
 ```
 
+`conda` will show you the packages that will be downloaded,
+and you can press enter to proceed with the installation.
+If you want to answer `yes` by default and skip this confirmation step,
+you can replace `conda install` with `conda install -y`.
+
 > Note: we will use many more packages than those listed above across the MDS program, however we will manage these using virtual environments (which you will learn about in DSCI 521: Platforms for Data Science).
 
 ## Jupyter extensions
-We will be using several Jupyter extensions that help us use Juypter notebooks more smoothly with Git & GitHub. To install them, paste the following in the terminal below:
+
+We will be using the Jupytext Python package and the JupyterLab git extension to facilitate using Jupyter notebooks with Git & GitHub. Install them via the following commands:
 
 ```
-conda install --yes nodejs=10.*
+conda install nodejs=10.*
 pip install --upgrade jupyterlab-git
-conda install --yes jupytext=1.*
+conda install jupytext=1.*
 jupyter lab build
 ```
 
-## R, XQuartz,IRkernel and RStudio
-We will be using R, another programming language, a lot in the program. We will use R both in Jupyter notebooks and in RStudio. To have R work in Jupyter notebooks we will also have to install the IR kernel. Finally, some R packages rely on the dependency XQuartz which no longer ships with the Mac OS, thus we need to install it separately.
+To test that your JupyerLab installation is functional, you can type `jupyter lab` into a terminal, which should open a new tab in your default browser with the JupyterLab interface.
+
+## R, XQuartz, IRkernel and RStudio
+
+R is another programming language that we will be using a lot in the MDS program. We will use R both in Jupyter notebooks and in RStudio.
 
 ### R
+
 Go to [https://cran.r-project.org/bin/macosx/](https://cran.r-project.org/bin/macosx/) and download the latest version of R for Mac (Should look something like this: R-3.6.1.pkg). Open the file and follow the installer instructions.
 
 After installation, in Terminal type the following to ask for the version:
@@ -192,7 +220,8 @@ After installation, in Terminal type the following to ask for the version:
 R --version
 ```
 
-you should see something like this if you were successful:
+You should see something like this if you were successful:
+
 ```
 R version 4.0.0 (2020-04-24) -- "Arbor Day"
 Copyright (C) 2020 The R Foundation for Statistical Computing
@@ -205,34 +234,43 @@ For more information about these matters see
 https://www.gnu.org/licenses/.
 ```
 
-Note: Although it is possible to install R through conda, we highly recommend not doing so. In case you have already installed R using conda you can remove it by executing `conda uninstall r-base`.
+> Note: Although it is possible to install R through conda, we highly recommend not doing so. In case you have already installed R using conda you can remove it by executing `conda uninstall r-base`.
 
 ### XQuartz
 
 Some R packages rely on the dependency XQuartz which no longer ships with the Mac OS, thus we need to install it separately. Download it from here: [https://www.xquartz.org/](https://www.xquartz.org/) and follow the installation instructions.
 
 ### RStudio
-Chose and download the Mac version of RStudio from [https://www.rstudio.com/products/rstudio/download/#download](https://www.rstudio.com/products/rstudio/download/#download). Open the file and follow the installer instructions.
 
-To see if you were successful, try opening RStudio by clicking on its icon (from Finder, Applications or Launchpad). It should open and looks something like this picture below:
+Download the macOS Desktop version of RStudio Preview from [https://rstudio.com/products/rstudio/download/preview/](https://rstudio.com/products/rstudio/download/preview/). Open the file and follow the installer instructions.
+
+To see if you were successful, try opening RStudio by clicking on its icon (from Finder, Applications or Launchpad). It should open and look something like this picture below:
 
 ![](/resources_pages/imgs/RStudio.png)
 
+
+### Essential R packages
+
+Next, install the key R packages needed for the start of MDS program,
+by typing the following into the R terminal in RStudio:
+
+```
+install.packages(c('tidyverse', 'blogdown', 'xaringan', 'renv'))
+```
+
+> Note: we will use many more packages than those listed above across the MDS program, however we will manage these using the `renv` package manager (which you will learn about in DSCI 521: Platforms for Data Science).
+
 ### IR kernel
 
+The `IRkernel` package is needed to make R work in Jupyter notebooks. To enable this kernel in the notebooks, install it and run the setup via the following two commands:
 Open RStudio and type the following commands into the Console panel:
 
 ```
-install.packages(c('IRkernel', 'tidyverse', 'blogdown', 'xaringan', 'renv'))
+install.packages('IRkernel')
+IRkernel::installspec()
 ```
 
-Next, open **terminal** and type the following:
-
-```
-R -e "IRkernel::installspec()"
-```
-
-To see if you were successful, try running Jupyter Lab and seeing if you have working R kernel. To launch the Jupyter Lab type the following in Terminal:
+To see if you were successful, try running Jupyter Lab and check if you have working R kernel. To launch the Jupyter Lab type the following in Terminal:
 
 ```
 jupyter lab
@@ -248,9 +286,9 @@ Sometimes a kernel loads, but doesn't work as expected. To test whether your ins
 
 ## LaTeX
 
-We will install the lightest possible version of LaTeX and it's necessary packages as possible so that we can render Jupyter notebooks and R Markdown documents to html and PDF.
+We will install the lightest possible version of LaTeX and it's necessary packages as possible so that we can render Jupyter notebooks and R Markdown documents to html and PDF. If you have previously installed LaTeX, please uninstall it before proceeding with these instructions.
 
-First, open RStudio and run the following commands to install the `tinytex` package and install `tinytex`:
+First, open RStudio and run the following commands to install the tinytex package and setup tinytex:
 
 ```
 install.packages('tinytex')
@@ -277,12 +315,42 @@ tlmgr install eurosym \
   trimspaces \
   ucs \
   ulem \
-  upquote 
+  upquote
 ```
 
-## PostgreSQL 
+To test that your latex installation is working with jupyter notebooks,
+launch `jupyter lab` from a terminal and open either a new notebook
+or the same one you used to test IRkernel above.
+Go to `File -> Export notebook as... -> Export Notebook to PDF`.
+If the PDF file is created,
+your LaTeX environment is setup correctly.
 
-We will be using PostgreSQL as our database management system. You can download the most recent version from from [here](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads). Follow the instructions for the installation. In the password page, type whatever password you want, but make sure you'll remember it later. For all the other options, use the default. 
+You can also check by typing the following to ask for the version of latex:
+
+```
+latex --version
+```
+
+You should see something like this if you were successful:
+
+```
+pdfTeX 3.14159265-2.6-1.40.21 (TeX Live 2020)
+kpathsea version 6.3.2
+Copyright 2020 Han The Thanh (pdfTeX) et al.
+There is NO warranty.  Redistribution of this software is
+covered by the terms of both the pdfTeX copyright and
+the Lesser GNU General Public License.
+For more information about these matters, see the file
+named COPYING and the pdfTeX source.
+Primary author of pdfTeX: Han The Thanh (pdfTeX) et al.
+Compiled with libpng 1.6.37; using libpng 1.6.37
+Compiled with zlib 1.2.11; using zlib 1.2.11
+Compiled with xpdf version 4.02
+```
+
+## PostgreSQL
+
+We will be using PostgreSQL as our database management system. You can download the most recent version from from [here](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads). Follow the instructions for the installation. In the password page, type whatever password you want, but make sure you'll remember it later. For all the other options, use the default.
 
 To test if the installation was succesfull open the `SQL Shell` app from the LaunchPad or applications directory. It should look like this if it is working correctly: 
 
@@ -290,9 +358,9 @@ To test if the installation was succesfull open the `SQL Shell` app from the Lau
 
 ## Docker
 
-You will use Docker to create reproducible, sharable and shippable computing environments for your analyses. For this you will need a Docker account. You can sign up for a free one here: https://store.docker.com/signup?next=%2F%3Fref%3Dlogin
+You will use Docker to create reproducible, sharable and shippable computing environments for your analyses. For this you will need a Docker account. You can [sign up for a free one here](https://store.docker.com/signup?next=%2F%3Fref%3Dlogin).
 
-After signing-up and signing into the Docker Store, go here: https://store.docker.com/editions/community/docker-ce-desktop-mac and click on the "Get Docker" button on the right hand side of the screen. Then follow the installation instructions on that screen. 
+After signing-up and signing into the Docker Store, go here: [https://store.docker.com/editions/community/docker-ce-desktop-mac](https://store.docker.com/editions/community/docker-ce-desktop-mac) and click on the "Get Docker" button on the right hand side of the screen. Then follow the installation instructions on that screen.
 
 To test if Docker is working, after installation open the Docker app by clicking on its icon (from Finder, Applications or Launchpad). Next open Terminal and type the following:
 ```
@@ -331,7 +399,7 @@ For more examples and ideas, visit:
 
 ## Visual Studio Code Extensions
 
-The real magic of VS Code is in the extensions that let you add languages, debuggers, and tools to your installation to support your specific workflow. Now that we have installed all our other Data Science tools, we can intall the VS Code extensions that work really well with them. From within VS Code you can open up the [Extension Marketplace](https://code.visualstudio.com/docs/editor/extension-gallery) to browse and install extensions by clicking on the Extensions icon in the Activity Bar indicated in the figure below.
+The real magic of VS Code is in the extensions that let you add languages, debuggers, and tools to your installation to support your specific workflow. Now that we have installed all our other Data Science tools, we can intall the VS Code extensions that work really well with them. From within VS Code you can open up the [Extension Marketplace (read more here)](https://code.visualstudio.com/docs/editor/extension-gallery) to browse and install extensions by clicking on the Extensions icon in the Activity Bar indicated in the figure below.
 
 ![](/resources_pages/imgs/vscode.png)
 
@@ -345,9 +413,10 @@ To install an extension, you simply search for it in the search bar, click the e
 - (Optional) Material Icon Theme (great-looking custom file icons!)
 - (Optional) Bracket Pair Colorizer 2 (add colour to help distinguish your brackets: (), [], {})
 
-This [video tutorial](https://www.youtube.com/watch?v=06I63_p-2A4) is an excellent introduction to using VS Code in Python.
+[This video tutorial](https://www.youtube.com/watch?v=06I63_p-2A4) is an excellent introduction to using VS Code in Python.
 
 ## Attributions
+
 * [Harvard CS109](http://cs109.github.io/2015/)
 * [UBC STAT 545](http://stat545.com/packages01_system-prep.html#mac-os-system-prep) licensed under the [CC BY-NC 3.0](https://creativecommons.org/licenses/by-nc/3.0/legalcode).
 * [Software Carpentry](https://software-carpentry.org/)

--- a/resources_pages/install_ds_stack_mac.md
+++ b/resources_pages/install_ds_stack_mac.md
@@ -260,14 +260,20 @@ install.packages(c('tidyverse', 'blogdown', 'xaringan', 'renv'))
 
 > Note: we will use many more packages than those listed above across the MDS program, however we will manage these using the `renv` package manager (which you will learn about in DSCI 521: Platforms for Data Science).
 
-### IR kernel
+### IRkernel
 
-The `IRkernel` package is needed to make R work in Jupyter notebooks. To enable this kernel in the notebooks, install it and run the setup via the following two commands:
-Open RStudio and type the following commands into the Console panel:
+The `IRkernel` package is needed to make R work in Jupyter notebooks. To enable this kernel in the notebooks, install by pasting the following command into the RStudio Console:
 
 ```
 install.packages('IRkernel')
-IRkernel::installspec()
+```
+
+Next, open a terminal and type the following
+(you can't use RStudio for this step
+since it doesn't honor $PATH changes in ~/.bash_profile)
+
+```
+R -e "IRkernel::installspec()"
 ```
 
 To see if you were successful, try running Jupyter Lab and check if you have working R kernel. To launch the Jupyter Lab type the following in Terminal:

--- a/resources_pages/install_ds_stack_ubuntu.md
+++ b/resources_pages/install_ds_stack_ubuntu.md
@@ -284,7 +284,7 @@ install.packages('IRkernel')
 IRkernel::installspec()
 ```
 
-To see if you were successful, try running Jupyter Lab and check if you have working R kernel. To launch the Jupyter Lab type the following in the Windows Powershell:
+To see if you were successful, try running Jupyter Lab and check if you have working R kernel. To launch Jupyter Lab, type the following in a terminal:
 
 ```
 jupyter lab

--- a/resources_pages/install_ds_stack_ubuntu.md
+++ b/resources_pages/install_ds_stack_ubuntu.md
@@ -244,6 +244,8 @@ For more information about these matters see
 https://www.gnu.org/licenses/.
 ```
 
+> Note: Although it is possible to install R through conda, we highly recommend not doing so. In case you have already installed R using conda you can remove it by executing `conda uninstall r-base`.
+
 ### RStudio
 
 Download the Ubuntu 18/Debian 10 Desktop version of RStudio Preview from [https://rstudio.com/products/rstudio/download/preview/](https://rstudio.com/products/rstudio/download/preview/). Open the file and follow the installer instructions.
@@ -282,7 +284,7 @@ install.packages('IRkernel')
 IRkernel::installspec()
 ```
 
-To see if you were successful, try running Jupyter Lab and seeing if you have working R kernel. To launch the Jupyter Lab type the following in the Windows Powershell:
+To see if you were successful, try running Jupyter Lab and check if you have working R kernel. To launch the Jupyter Lab type the following in the Windows Powershell:
 
 ```
 jupyter lab
@@ -406,7 +408,7 @@ After signing-up, you also need to install Docker **CE** for Ubuntu. Follow the 
 
 Next, [follow the Linux post installation steps here](https://docs.docker.com/engine/install/linux-postinstall/) so that you can run Docker without typing `sudo`, and confirm that docker is working by following the verification instructions on that same page.
 
-### Customizing VS Code with Extensions
+## Visual Studio Code Extensions
 
 The real magic of VS Code is in the extensions that let you add languages, debuggers, and tools to your installation to support your specific workflow. From within VS Code you can open up the [Extension Marketplace (read more here)](https://code.visualstudio.com/docs/editor/extension-gallery) to browse and install extensions by clicking on the Extensions icon in the Activity Bar indicated in the figure below.
 


### PR DESCRIPTION
@ttimbers This includes the changes we made in #56 and a few minor updates to the Ubuntu instructions that I noticed when going through the mac instructions. A couple of questions:

- During the conda instal on mac, do they need to select to run conda init anywhere? If so I guess this will be for their default shell (unless there is an option for that), should we add a note that these instructions should be followed in order? Students might not if they already have some packages installed.
- Is there no path change needed for tinytex to work with jupyter on mac?

I will join office hours in about 10 min.
