### PR TITLE
Prevent navigation bar from covering headings when internal links are clicked

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -782,3 +782,9 @@ td.gutter {
   font-style: italic;
   font-size: 16px;
 }
+
+/* Prevent navigation bar from covering headings when internal links are clicked, */
+/* e.g. in a ToC. */
+html {
+  scroll-padding-top: 70px; /* height of sticky header */
+}


### PR DESCRIPTION
Current behavior after clicking the "Google Chrome" ToC link:
![image](https://user-images.githubusercontent.com/4560057/88958193-f94ed380-d254-11ea-902a-407efea28bdd.png)

---

This PR:
![image](https://user-images.githubusercontent.com/4560057/88958102-d6242400-d254-11ea-94b3-a5639da1bdca.png)

Tested on chrome and firefox. From https://stackoverflow.com/a/56467997/2166823
