### PR TITLE
Update nbconvert on Windows to make it work with tinytex

### DIFF
--- a/resources_pages/install_ds_stack_windows.md
+++ b/resources_pages/install_ds_stack_windows.md
@@ -299,6 +299,16 @@ and you can press enter to proceed with the installation.
 If you want to answer `yes` by default and skip this confirmation step,
 you can replace `conda install` with `conda install -y`.
 
+Next we will update `nbconvert` (which was installed with `jupyterlab`),
+because we require a more recent version to make it work well with `tinytex` on Windows,
+which we will install later.
+To install the latest version directly from GitHub,
+we need to use the `pip` package manager instead of `conda`:
+
+```
+pip install git+https://github.com/jupyter/nbconvert.git@86ea045
+```
+
 > Note: we will use many more packages than those listed above across the MDS program, however we will manage these using virtual environments (which you will learn about in DSCI 521: Platforms for Data Science).
 
 ### JupyterLab setup
@@ -514,8 +524,6 @@ or the same one you used to test IRkernel above.
 Go to `File -> Export notebook as... -> Export Notebook to PDF`.
 If the PDF file is created,
 your LaTeX environment is set up correctly.
-
-> Note if you see an error that says "Undefined control sequence", you need to edit a configuration file for Jupyter's PDF export. Open a terminal and paste `code "/c/Users/${USERNAME}/miniconda3/Lib/site-packages/nbconvert/exporters/pdf.py"`. On line 66, it says `writer = Instance("nbconvert.writers.FilesWriter", args=(), kw={'build_directory': '.'})`, replace this line with the following line `writer = Instance("nbconvert.writers.FilesWriter", args=(), kw={'build_directory': ''})` (removing the period close to the end). Now try to generate a PDF from JupyterLab again.
 
 ## Make
 


### PR DESCRIPTION
I decided to fix the install at the commit I made
instead of waiting for the next alpha release.
I also decided to only include this in the Windows instructions,
since it is a workaround for file paths on Windows specifically,
and I don't think the advantages of having all OSes run the same version
outweights the risks with running a recent version directly from Github
on more machines.

@ttimbers After we merge this
I will post the message to students
that I sent to you in slack.

Close #74