### PR TITLE
Add function for man-like command on windows

### DIFF
--- a/resources_pages/install_ds_stack_windows.md
+++ b/resources_pages/install_ds_stack_windows.md
@@ -734,6 +734,8 @@ HISTFILESIZE=50000
 # Run Python and Docker in compatibility mode when started from an interactive shell
 alias python="winpty python"
 alias docker="winpty docker"
+# `man` function to display help messages with a pager as on Unix
+man() { $1 --help | less }
 ```
 
 ## Post-installation notes


### PR DESCRIPTION
The main reason for adding this is to get students on Windows familiar with asking for help using `man` and navigating `less`,
which is a workflow they will likely encounter when working elsewhere.
I was going back and forth on wether to introduce this in the setup or during lecture,
but I think it is better if they just copy this in and I will just explain it briefly during a lecture instead.