### PR TITLE
Start the MDS calendar weeks on Mondays

### DIFF
--- a/calendar.md
+++ b/calendar.md
@@ -3,7 +3,7 @@ layout: page
 title: MDS Calendar
 ---
 
-<iframe src="https://calendar.google.com/calendar/b/2/embed?showTitle=0&amp;showPrint=0&amp;showTz=1&amp;mode=WEEK&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=luh223qsrlqmts9i86p7v6m204%40group.calendar.google.com&amp;color=%23711616&amp;src=vbqklh5f7qpkoplteurlb9r1ps%40group.calendar.google.com&amp;color=%235F6B02&amp;src=1ld9ugd459qepa0eb0e4b77kl0%40group.calendar.google.com&amp;color=%232952A3&amp;src=ejhrb9q92fkngsl2jmag6lccvg%40group.calendar.google.com&amp;color=%23BE6D00&amp;src=7mfpluc2hrdcbvko25bd6n2130%40group.calendar.google.com&amp;color=%236B3304&amp;src=51mn8ie2s8tfl2gum1f7r46n70%40group.calendar.google.com&amp;color=%238E24AA&amp;ctz=America%2FVancouver" style="border-width:0" width="800" height="800" frameborder="0" scrolling="no"></iframe>
+<iframe src="https://calendar.google.com/calendar/b/2/embed?showTitle=0&amp;showPrint=0&amp;showTz=1&amp;mode=WEEK&amp;height=600&amp;wkst=2&amp;bgcolor=%23FFFFFF&amp;src=luh223qsrlqmts9i86p7v6m204%40group.calendar.google.com&amp;color=%23711616&amp;src=vbqklh5f7qpkoplteurlb9r1ps%40group.calendar.google.com&amp;color=%235F6B02&amp;src=1ld9ugd459qepa0eb0e4b77kl0%40group.calendar.google.com&amp;color=%232952A3&amp;src=ejhrb9q92fkngsl2jmag6lccvg%40group.calendar.google.com&amp;color=%23BE6D00&amp;src=7mfpluc2hrdcbvko25bd6n2130%40group.calendar.google.com&amp;color=%236B3304&amp;src=51mn8ie2s8tfl2gum1f7r46n70%40group.calendar.google.com&amp;color=%238E24AA&amp;ctz=America%2FVancouver" style="border-width:0" width="800" height="800" frameborder="0" scrolling="no"></iframe>
 
 Legend:
 


### PR DESCRIPTION
I'll admit this is mostly because I get myself confused when I look at the MDS calendar and if you think students will be confused if we switch, then let's keep it as is. In an attempt to argue my personal preference with from a more objective angle, Mon is ISO 8601, which is what we promote for date formats otherwise (but I agree is not as important here).