### PR TITLE
Installation notes for Otter-Grader

### DIFF
--- a/resources_pages/install_ds_stack_mac.md
+++ b/resources_pages/install_ds_stack_mac.md
@@ -239,9 +239,9 @@ A package needs to go through thorough testing before it is included in the defa
 which is good for stability,
 but also means that new versions will be delayed and fewer packages are available overall.
 There is a community-driven effort called the [conda-forge (read more here)](https://conda-forge.org/),
-which provides more up to date packages
+which provides more up to date packages.
 To enable us to access the most up to date version of the Python packages we are going to use,
-we will add the more up to date  channel,
+we will add the more up to date channel.
 To add the conda-forge channel by typing the following in the terminal:
 
 ```bash
@@ -256,6 +256,7 @@ After running that command
 and you can press enter to proceed with the installation.
 If you want to answer `yes` by default and skip this confirmation step,
 you can replace `conda install` with `conda install -y`.
+Also note that we may occasionally need to install packages using `pip`, the standard Python package manager. The installation command is very similar to that of `conda`: `pip install <package-name>`.
 Let's try this out in the next section,
 by installing some of the key packages we will use in MDS.
 
@@ -270,8 +271,16 @@ and the LSP packages fill the same function for our code.
 Install them via the following commands:
 
 ```bash
-conda install pandas jupyterlab jupyterlab-git jupyterlab-spellchecker jupytext jupyterlab-lsp jupyter-lsp-python
+conda install pandas memory_profiler jupyterlab jupyterlab-git jupyterlab-spellchecker jupytext jupyterlab-lsp jupyter-lsp-python
 ```
+
+We will grade part of your assignments in MDS using the Otter-Grader package. For your Jupyter-based assignments, you need to install Otter-Grader using the following command:
+
+```bash
+pip install otter-grader
+```
+
+> Note: You will also install Otter-Grader for R in the later sections of this guide.
 
 To test that your JupyterLab installation is functional, you can type `jupyter lab` into a terminal,
 which should open a new tab in your default browser with the JupyterLab interface.
@@ -342,6 +351,12 @@ install.packages(c('tidyverse', 'blogdown', 'xaringan', 'renv', 'usethis', 'devt
 ```
 
 > **Note:** we will use many more packages than those listed above across the MDS program, however we will manage these using the `renv` package manager (which you will learn about in DSCI 521: Platforms for Data Science).
+
+As mentioned earlier, you will need the Otter-Grader package in R as well, which you can install by runninng the following command in the R console:
+
+```R
+devtools::install_github("ucbds-infra/ottr@stable")
+```
 
 ### IRkernel
 

--- a/resources_pages/install_ds_stack_mac.md
+++ b/resources_pages/install_ds_stack_mac.md
@@ -347,16 +347,12 @@ by opening up RStudio and
 typing the following into the R console inside RStudio:
 
 ```R
-install.packages(c('tidyverse', 'blogdown', 'xaringan', 'renv', 'usethis', 'devtools', 'languageserver'))
+install.packages(c('tidyverse', 'blogdown', 'xaringan', 'renv', 'usethis', 'devtools', 'languageserver', 'janitor', 'gapminder', 'readxl'))
+devtools::install_github("ucbds-infra/ottr@stable")
+devtools::install_github("ttimbers/canlang")
 ```
 
 > **Note:** we will use many more packages than those listed above across the MDS program, however we will manage these using the `renv` package manager (which you will learn about in DSCI 521: Platforms for Data Science).
-
-As mentioned earlier, you will need the Otter-Grader package in R as well, which you can install by runninng the following command in the R console:
-
-```R
-devtools::install_github("ucbds-infra/ottr@stable")
-```
 
 ### IRkernel
 

--- a/resources_pages/install_ds_stack_ubuntu.md
+++ b/resources_pages/install_ds_stack_ubuntu.md
@@ -226,9 +226,9 @@ A package needs to go through thorough testing before it is included in the defa
 which is good for stability,
 but also means that new versions will be delayed and fewer packages are available overall.
 There is a community-driven effort called the [conda-forge (read more here)](https://conda-forge.org/),
-which provides more up to date packages
+which provides more up to date packages.
 To enable us to access the most up to date version of the Python packages we are going to use,
-we will add the more up to date  channel,
+we will add the more up to date channel.
 To add the conda-forge channel by typing the following in the terminal:
 
 ```bash
@@ -243,6 +243,7 @@ After running that command
 and you can press enter to proceed with the installation.
 If you want to answer `yes` by default and skip this confirmation step,
 you can replace `conda install` with `conda install -y`.
+Also note that we may occasionally need to install packages using `pip`, the standard Python package manager. The installation command is very similar to that of `conda`: `pip install <package-name>`.
 Let's try this out in the next section,
 by installing some of the key packages we will use in MDS.
 
@@ -257,8 +258,16 @@ and the LSP packages fill the same function for our code.
 Install them via the following commands:
 
 ```bash
-conda install pandas jupyterlab jupyterlab-git jupyterlab-spellchecker jupytext jupyterlab-lsp jupyter-lsp-python
+conda install pandas memory_profiler jupyterlab jupyterlab-git jupyterlab-spellchecker jupytext jupyterlab-lsp jupyter-lsp-python
 ```
+
+We will grade part of your assignments in MDS using the Otter-Grader package. For your Jupyter-based assignments, you need to install Otter-Grader using the following command:
+
+```bash
+pip install otter-grader
+```
+
+> Note: You will also install Otter-Grader for R in the later sections of this guide.
 
 To test that your JupyterLab installation is functional, you can type `jupyter lab` into a terminal,
 which should open a new tab in your default browser with the JupyterLab interface.
@@ -352,6 +361,12 @@ install.packages(c('tidyverse', 'blogdown', 'xaringan', 'renv', 'usethis', 'devt
 ```
 
 > **Note:** We will use many more packages than those listed above across the MDS program, however we will manage these using the `renv` package manager (which you will learn about in DSCI 521: Platforms for Data Science).
+
+As mentioned earlier, you will need the Otter-Grader package in R as well, which you can install by runninng the following command in the R console:
+
+```R
+devtools::install_github("ucbds-infra/ottr@stable")
+```
 
 ### IRkernel
 

--- a/resources_pages/install_ds_stack_ubuntu.md
+++ b/resources_pages/install_ds_stack_ubuntu.md
@@ -356,16 +356,10 @@ Next, install the key R packages needed for the start of MDS program,
 by opening up RStudio and
 typing the following into the R console inside RStudio:
 
-```
-install.packages(c('tidyverse', 'blogdown', 'xaringan', 'renv', 'usethis', 'devtools', 'languageserver'))
-```
-
-> **Note:** We will use many more packages than those listed above across the MDS program, however we will manage these using the `renv` package manager (which you will learn about in DSCI 521: Platforms for Data Science).
-
-As mentioned earlier, you will need the Otter-Grader package in R as well, which you can install by runninng the following command in the R console:
-
 ```R
+install.packages(c('tidyverse', 'blogdown', 'xaringan', 'renv', 'usethis', 'devtools', 'languageserver', 'janitor', 'gapminder', 'readxl'))
 devtools::install_github("ucbds-infra/ottr@stable")
+devtools::install_github("ttimbers/canlang")
 ```
 
 ### IRkernel

--- a/resources_pages/install_ds_stack_windows.md
+++ b/resources_pages/install_ds_stack_windows.md
@@ -522,20 +522,10 @@ Next, install the key R packages needed for the start of MDS program,
 by opening up RStudio and
 typing the following into the R console inside RStudio:
 
-```
-install.packages(c('tidyverse', 'blogdown', 'xaringan', 'renv', 'usethis', 'devtools', 'languageserver'))
-```
-
-> **Note:** It might take a rather long time to install these pacakges.
-
-If you get a prompt asking if you want to install packages that need compilation from sources, click "Yes".
-
-> **Note**: We will use many more packages than those listed above across the MDS program, however we will manage these using the `renv` package manager (which you will learn about in DSCI 521: Platforms for Data Science).
-
-As mentioned earlier, you will need the Otter-Grader package in R as well, which you can install by runninng the following command in the R console:
-
 ```R
+install.packages(c('tidyverse', 'blogdown', 'xaringan', 'renv', 'usethis', 'devtools', 'languageserver', 'janitor', 'gapminder', 'readxl'))
 devtools::install_github("ucbds-infra/ottr@stable")
+devtools::install_github("ttimbers/canlang")
 ```
 
 ### IRkernel

--- a/resources_pages/install_ds_stack_windows.md
+++ b/resources_pages/install_ds_stack_windows.md
@@ -360,9 +360,9 @@ A package needs to go through thorough testing before it is included in the defa
 which is good for stability,
 but also means that new versions will be delayed and fewer packages are available overall.
 There is a community-driven effort called the [conda-forge (read more here)](https://conda-forge.org/),
-which provides more up to date packages
+which provides more up to date packages.
 To enable us to access the most up to date version of the Python packages we are going to use,
-we will add the more up to date  channel,
+we will add the more up to date channel.
 To add the conda-forge channel by typing the following in the terminal:
 
 ```bash
@@ -377,6 +377,7 @@ After running that command
 and you can press enter to proceed with the installation.
 If you want to answer `yes` by default and skip this confirmation step,
 you can replace `conda install` with `conda install -y`.
+Also note that we may occasionally need to install packages using `pip`, the standard Python package manager. The installation command is very similar to that of `conda`: `pip install <package-name>`.
 Let's try this out in the next section,
 by installing some of the key packages we will use in MDS.
 
@@ -391,8 +392,16 @@ and the LSP packages fill the same function for our code.
 Install them via the following commands:
 
 ```bash
-conda install pandas jupyterlab jupyterlab-git jupyterlab-spellchecker jupytext jupyterlab-lsp jupyter-lsp-python
+conda install pandas memory_profiler jupyterlab jupyterlab-git jupyterlab-spellchecker jupytext jupyterlab-lsp jupyter-lsp-python
 ```
+
+We will grade part of your assignments in MDS using the Otter-Grader package. For your Jupyter-based assignments, you need to install Otter-Grader using the following command:
+
+```bash
+pip install otter-grader
+```
+
+> Note: You will also install Otter-Grader for R in the later sections of this guide.
 
 To test that your JupyterLab installation is functional, you can type `jupyter lab` into a terminal,
 which should open a new tab in your default browser with the JupyterLab interface.
@@ -522,6 +531,12 @@ install.packages(c('tidyverse', 'blogdown', 'xaringan', 'renv', 'usethis', 'devt
 If you get a prompt asking if you want to install packages that need compilation from sources, click "Yes".
 
 > **Note**: We will use many more packages than those listed above across the MDS program, however we will manage these using the `renv` package manager (which you will learn about in DSCI 521: Platforms for Data Science).
+
+As mentioned earlier, you will need the Otter-Grader package in R as well, which you can install by runninng the following command in the R console:
+
+```R
+devtools::install_github("ucbds-infra/ottr@stable")
+```
 
 ### IRkernel
 


### PR DESCRIPTION
This PR is created for adding installation notes for the Otter-Grader tool, and another package called `memory_profiler`. I have added instructions for Mac, Ubuntu and Windows.

@ttimbers In lecture 4 of 511 where I will teach coding styles, I should demonstrate linting and autoformatting which requires, e.g. `flake8`, `pylint` and `black`. We removed installation instructions for these in the latest installation instructions update as we will be using `jupyter-lsp` for linting. Is it ok if I use `!conda install ...` inside of the notebooks to install these packages on the fly, or should we include installation notes for these too? Tom has also used a Jupyter lab extension called `jupyterlab_code_formatter` to demo autoformatting. He has used `!conda install ...` inside notebooks for all of these packages.