### PR TITLE
Clarify regarding leaving and re-entering the room

### DIFF
--- a/policies.md
+++ b/policies.md
@@ -84,7 +84,7 @@ For Block 2 onward of 2021-22, the following are also **NOT** permitted:
 
 - taking a quiz from a remote location without prior permission (see below on how to obtain permission)
 - leaving the quiz room early with your laptop
-- leaving and re-entering the quiz room (other than for purposes such as using the washroom)
+- leaving and re-entering the quiz room (unless approved by the instructor, please talk to the instructor before the quiz if you think you might have to leave the room during the quiz)
 
 Failing to observe the above expectations may result in a zero grade for the quiz in question.
 


### PR DESCRIPTION
I had a student finish early and then asked if they could go to the bathroom with only 10 min left of the quiz. They would have disrupted another 4 students that were still writing the quiz since they would have needed to stand up for this student to pass. I asked if they could wait instead, and I think we can clarify in the instructions so that students let us know beforehand if they have a condition that might cause them to need to leave the room and then we can ask them to sit at the end of the row, so it is both easier for them to leave and no one else is disrupted. 