### PR TITLE
Add a note to students to not modify the bashrc file on MacOS and Windows

### DIFF
--- a/resources_pages/install_ds_stack_mac.md
+++ b/resources_pages/install_ds_stack_mac.md
@@ -224,11 +224,17 @@ open your `~/.bashrc` file:
 code ~/.bashrc
 ```
 
-And append the following line:
+And append the following lines:
 
 ```bash
+# Do NOT add anything to this file, use `~/.bash_profile` instead.
+# The next line automatically loads your `~/.bash_profile`
+# any time a program tries to read your `~/.bashrc` file.
 if [ -f ~/.bash_profile ]; then . ~/.bash_profile; fi
 ```
+
+The comment is a reminder to your future self
+who might open up this file a few months from now =)
 
 ## Python, Conda, and JupyterLab
 

--- a/resources_pages/install_ds_stack_windows.md
+++ b/resources_pages/install_ds_stack_windows.md
@@ -275,11 +275,17 @@ open your `~/.bashrc` file:
 code ~/.bashrc
 ```
 
-And append the following line:
+And append the following lines:
 
 ```bash
+# Do NOT add anything to this file, use `~/.bash_profile` instead.
+# The next line automatically loads your `~/.bash_profile`
+# any time a program tries to read your `~/.bashrc` file.
 if [ -f ~/.bash_profile ]; then . ~/.bash_profile; fi
 ```
+
+The comment is a reminder to your future self
+who might open up this file a few months from now =)
 
 ### Setting Git Bash as the default VS Code terminal profile
 


### PR DESCRIPTION
This is to resolve the discussion we had on slack @chendaniely and @flor14 . As long as there are no programs that automatically adds content to `bashrc` on Mac and Windows, then this solution should be sufficient.

I don't think we need to add the echo message to students by default, but it something that is helpful for us to use if we are troubleshooting with them (and could be good to have in our own Mac/Windows configs if we want to explore further which programs are trying to read bashrc on these platforms). See https://ubc-mds.slack.com/archives/GP36NE5PG/p1673584314927949 for the full discussion.