### PR TITLE
small installation instructions updates for ubuntu and mac

### DIFF
--- a/resources_pages/install_ds_stack_mac.md
+++ b/resources_pages/install_ds_stack_mac.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: macOS
-subtitle: MDS software stack install instructions for macOS 2022/23
+subtitle: MDS software stack install instructions for macOS 2025/26
 ---
 
 <!-- Open links in a new tab unless they have the `{:target="_self"}` attribute -->
@@ -31,8 +31,10 @@ subtitle: MDS software stack install instructions for macOS 2022/23
 - [Post-installation notes](#post-installation-notes){:target="_self"}
 
 
-> Note that there are differences in some parts of the installation for Mac computers with the Intel chip and the Mac M1 / Mac M2.
-
+> **Important**
+> Note that there are differences in some parts of the installation for Mac computers with [recent Apple Silicon (Mac M1-M4) and earlier Intel chips](https://support.apple.com/en-us/116943). If you have a newer Mac laptop, make sure to chose relevant versions (usually denoted as Apple Silicon, Mac M1-M4, Mac arm64 or Darwin).
+> For older Intel Macs, in all the sections below, if you are presented with the choice to download either a 64-bit (also called x64)
+or a 32-bit (also called x86) version of the application **always** choose the 64-bit version.
 
 ## Installation notes
 
@@ -42,19 +44,6 @@ If you have already installed Git, Latex, or any of the R or Python related pack
 In order to be able to support you effectively
 and minimize setup issues and software conflicts,
 we require all students to install the software stack the same way.
-
-In all the sections below,
-if you are presented with the choice to download either a 64-bit (also called x64)
-or a 32-bit (also called x86) version of the application **always** choose the 64-bit version.
-
-
-> **Important**
-> Mac computers are transitioning from
-> Intel processors to [Apple silicon](https://support.apple.com/en-us/HT211814).
-> If you have a new laptop (Mac M1 or Mac M2)
-> for some software
-> you will have to use a different installer
-> than Macs with Intel processors.
 
 Once you have completed these installation instructions,
 make sure to follow the post-installation notes at the end
@@ -72,7 +61,7 @@ In MDS we will be using many tools that work most reliably on Google Chrome and 
 
 ## Password manager
 
-A password manager is an efficient and convenient measure to protect your online accounts from most common threats. While you don't strictly need to use one for any of the courses in MDS, we **highly recommend** that you set one up for your own benefit. Examples of reliable password managers include the ones built into Chrome and Firefox, [Bitwarden](https://bitwarden.com/), and [KeePassXC](https://keepassxc.org/) (if you prefer to sync your passwords manually).
+A password manager is an efficient and convenient measure to protect your online accounts from most common threats. While you don't strictly need to use one for any of the courses in MDS, we **highly recommend** that you set one up for your own benefit. Examples of reliable password managers include the ones built into Chrome and Firefox, as well as [Bitwarden](https://bitwarden.com/), and [KeePassXC](https://keepassxc.org/) (if you prefer to sync your passwords manually).
 
 ## Slack
 
@@ -108,10 +97,11 @@ You will have to quit all instances of open Terminals and then **restart** the T
 
 The open-source text editor Visual Studio Code (VS Code) is both a powerful text editor and a full-blown Python IDE, which we will use for more complex analysis. You can download and install the macOS version of VS Code from the VS code website [https://code.visualstudio.com/download](https://code.visualstudio.com/download).
 
-Pay attention here if you have to download the "Intel Chip" or "Apple silicon" installer.
+Pay attention here if you have to download the "Apple silicon" or "Intel Chip" installer.
 
 Once the download is finished, click "Open with Archive utility", and move the extracted VS Code application from "Downloads" to "Applications".
-In addition to reading the [getting started instructions](https://code.visualstudio.com/docs/setup/mac), **be sure to follow the ["Launching from the command line"](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line) steps as well.**
+
+**Be sure to follow both the ["Install VS Code on macOS"](https://code.visualstudio.com/docs/setup/mac#_install-vs-code-on-macos) AND ["Launch VS Code from the command line"](https://code.visualstudio.com/docs/setup/mac#_launch-vs-code-from-the-command-line) steps as well.**
 
 You can test that VS code is installed and can be opened from Terminal by **restarting** terminal and typing the following command:
 
@@ -122,10 +112,12 @@ code --version
 you should see something like this if you were successful:
 
 ```
-1.103.0
+1.103.1
+360a4e4fd251bfce169a4ddf857c7d25d1ad40da
+arm64
 ```
 
-> **Note:** If you get an error message such as `-bash: code: command not found`, but you can see the VS Code application has been installed, then something went wrong with setting up the launch from the command line. Try following [these instructions](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line) again, in particular you might want to try the described manual method of adding VS Code to your path.
+> **Note:** If you get an error message such as `-bash: code: command not found`, but you can see the VS Code application has been installed, then something went wrong with setting up the launch from the command line. Get back to [these instructions](https://code.visualstudio.com/docs/setup/mac#_launch-vs-code-from-the-command-line) again, in particular you might want to try the described manual method of adding VS Code to your path.
 
 ## GitHub
 
@@ -167,7 +159,7 @@ git --version
 you should see something like this (does not have to be the exact same version) if you were successful:
 
 ```
-git version 2.39.2 (Apple Git-143)
+git version 2.39.5 (Apple Git-154)
 ```
 
 > **Note:** If you run into trouble, please see that Install Git > Mac OS section from [Happy Git and GitHub for the useR](http://happygitwithr.com/install-git.html#mac-os) for additional help or strategies for Git installation.
@@ -250,7 +242,7 @@ You can find the Mac ARM and Intel download links here: <https://conda-forge.org
 Make sure you use the `Miniforge3` installers.
 We will assume you downloaded the file into your `Downloads` folder.
 
-Once downloaded, open up a terminal and run the following command
+Once downloaded, open up a terminal and run the following command (adjusting for the name of the installer you downloaded, for example `Miniforge3-Darwin-arm64.sh`)
 
 ```bash
 bash ${HOME}/Downloads/Miniforge3.sh -b -p "${HOME}/miniforge3"
@@ -365,15 +357,9 @@ R --version
 You should see something like this if you were successful:
 
 ```
-R version 4.3.1 (2023-06-16) -- "Beagle Scouts"
-Copyright (C) 2023 The R Foundation for Statistical Computing
-Platform: aarch64-apple-darwin20 (64-bit)
-
-R is free software and comes with ABSOLUTELY NO WARRANTY.
-You are welcome to redistribute it under the terms of the
-GNU General Public License versions 2 or 3.
-For more information about these matters see
-https://www.gnu.org/licenses/.
+R version 4.5.1 (2025-06-13) -- "Great Square Root"
+Copyright (C) 2025 The R Foundation for Statistical Computing
+Platform: aarch64-apple-darwin20
 ```
 
 > **Note:** Although it is possible to install R through conda, we highly recommend not doing so. In case you have already installed R using conda you can remove it by executing `conda uninstall r-base`.
@@ -384,7 +370,7 @@ Some R packages rely on the dependency XQuartz which no longer ships with the Ma
 
 ### RStudio
 
-Download the macOS Desktop version (not Pro) of RStudio  [https://posit.co/download/rstudio-desktop/](https://posit.co/download/rstudio-desktop/). Open the file and follow the installer instructions.
+Download the macOS Desktop version (not Pro) of RStudio  [https://posit.co/download/rstudio-desktop/](https://posit.co/download/rstudio-desktop/). Remember that you have already installed R and can start with "Step 2: Install RStudio". Open the file and follow the installer instructions.
 
 To see if you were successful, try opening RStudio by clicking on its icon (from Finder, Applications or Launchpad). It should open and look something like this picture below:
 
@@ -422,8 +408,8 @@ Stan is the language we will be using later on in the program for Bayesian stati
 To install it open RStudio and install `rstan`
 
 ```R
-install.packages("StanHeaders", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
-install.packages("rstan", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
+install.packages("StanHeaders", repos = c("https://stan-dev.r-universe.dev", getOption("repos")))
+install.packages("rstan", repos = c("https://stan-dev.r-universe.dev", getOption("repos")))
 ```
 
 > **Note:** If you are asked to update packages during the installation via `devtools::install_github`, select the `None` option.
@@ -474,7 +460,7 @@ install.packages('IRkernel')
 ```
 
 Next, open a terminal and type the following
-(you can't use RStudio for this step
+(you **can't use RStudio** for this step
 since it doesn't honor `$PATH` changes in `~/.bash_profile`)
 
 ```bash
@@ -559,7 +545,7 @@ Quarto is an open-source scientific and technical publishing system that you can
 
 The [RStudio version that you have downloaded](https://quarto.org/docs/tools/rstudio.html) is already equipped with the last version of Quarto. You can check this by opening a new document in `File -> New File -> Quarto Document`.
 
-Quarto can be used outside RStudio as well, this is why we are going to install Quarto CLI. Please, download the [last version of Quarto CLI](https://quarto.org/docs/get-started/) for MacOs.
+Quarto can be used outside RStudio as well, this is why we are going to install Quarto CLI. Please, download the [last version of Quarto CLI](https://quarto.org/docs/get-started/) for MacOS.
 
 After the installation finishes, close all the terminals you may have open. Then, open a new one and try running this command:
 
@@ -661,7 +647,7 @@ Try this by going to `File -> Save and Export Notebook As... -> WebPDF`.
 
 ## PostgreSQL
 
-We will be using PostgreSQL as our database management system. You can download the most recent version of PostgreSQL from [here](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads). Follow the instructions for the installation. In the password page, type whatever password you want, **and make sure you save it using a password manager or similar so that you know what it is in November when the SQL course starts** (otherwise you will need to reinstall PostgreSQL). For all the other options, use the default. You do not need to run "StackBuilder" at the end of the installation (if you accidentally launch the StackBuilder, click "cancel", you don't need to check any boxes).
+We will be using PostgreSQL as our database management system. You can download PostgreSQL 16.10 from [here](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads). Follow the instructions for the installation. In the password page, type whatever password you want, **and make sure you save it using a password manager or similar so that you know what it is in November when the SQL course starts** (otherwise you will need to reinstall PostgreSQL). For all the other options, use the default. You do not need to run "StackBuilder" at the end of the installation (if you accidentally launch the StackBuilder, click "cancel", you don't need to check any boxes).
 
 To test if the installation was successful open the `SQL Shell` app from the LaunchPad or applications directory. You will be asked to setup your configuration:
 
@@ -679,7 +665,7 @@ If you are asked about stackbuilder, you can skip this for now.
 
 You will use Docker to create reproducible, sharable and shippable computing environments for your analyses. For this you will need a Docker account. You can [sign up for a free one here](https://store.docker.com/signup?next=%2F%3Fref%3Dlogin).
 
-After signing-up and signing into the Docker Store, go here: [https://store.docker.com/editions/community/docker-ce-desktop-mac](https://store.docker.com/editions/community/docker-ce-desktop-mac) and click on the button "Mac with Intel chip" or "Mac with Apple chip". Then follow the installation instructions on that screen to install the stable version.
+After signing-up and signing into the Docker Store, go here: [https://store.docker.com/editions/community/docker-ce-desktop-mac](https://store.docker.com/editions/community/docker-ce-desktop-mac) and click on the button "Docker Desktop for Mac with Apple silicon" or "Docker Desktop for Mac with Intel". Then follow the installation instructions on that screen to install the stable version.
 
 To test if Docker is working, after installation open the Docker app by clicking on its icon (from Finder, Applications or Launchpad). Next open Terminal and type the following:
 
@@ -834,7 +820,7 @@ alias grep='grep -i'
 
 Finally, download and save the MDS help script via the following command.
 
-```
+```bash
 curl -Sso ~/.mds-help.sh https://raw.githubusercontent.com/UBC-MDS/UBC-MDS.github.io/master/resources_pages/mds-help.sh
 ```
 

--- a/resources_pages/install_ds_stack_ubuntu.md
+++ b/resources_pages/install_ds_stack_ubuntu.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Ubuntu
-subtitle: MDS software stack install instructions for Ubuntu 2022/23
+subtitle: MDS software stack install instructions for Ubuntu 2025/26
 ---
 
 <!-- Open links in a new tab unless they have the `{:target="_self"}` attribute -->
@@ -70,7 +70,7 @@ In MDS we will be using many tools that work most reliably on Google Chrome and 
 
 ## Password manager
 
-A password manager is an efficient and convenient measure to protect your online accounts from most common threats. While you don't strictly need to use one for any of the courses in MDS, we **highly recommend** that you set one up for your own benefit. Examples of reliable password managers include the ones built into Chrome and Firefox, [Bitwarden](https://bitwarden.com/), and [KeePassXC](https://keepassxc.org/) (if you prefer to sync your passwords manually).
+A password manager is an efficient and convenient measure to protect your online accounts from most common threats. While you don't strictly need to use one for any of the courses in MDS, we **highly recommend** that you set one up for your own benefit. Examples of reliable password managers include the ones built into Chrome and Firefox, as well as [Bitwarden](https://bitwarden.com/), and [KeePassXC](https://keepassxc.org/) (if you prefer to sync your passwords manually).
 
 ## Slack
 
@@ -103,7 +103,7 @@ code --version
 you should see something like this if you were successful (does not have to be the exact same version):
 
 ```
-1.103.0
+1.103.1
 ```
 
 ## GitHub
@@ -145,7 +145,7 @@ git --version
 you should see something like this if you were successful:
 
 ```
-git version 2.34.1
+git version 2.39.5
 ```
 
 ### Configuring Git user info
@@ -205,7 +205,7 @@ You can find the Mac ARM and Intel download links here: <https://conda-forge.org
 Make sure you use the `Miniforge3` installers.
 We will assume you downloaded the file into your `Downloads` folder.
 
-Once downloaded, open up a terminal and run the following command
+Once downloaded, open up a terminal and run the following command (adjusting for the name of the installer you downloaded, for example `Miniforge3-Linux-x86_64.sh`)
 
 ```bash
 bash ${HOME}/Downloads/Miniforge3.sh -b -p "${HOME}/miniforge3"
@@ -329,15 +329,9 @@ R --version
 You should see something like this if you were successful:
 
 ```
-R version 4.3.1 (2023-06-16) -- "Beagle Scouts"
-Copyright (C) 2023 The R Foundation for Statistical Computing
+R version 4.5.1 (2025-06-13) -- "Great Square Root"
+Copyright (C) 2025 The R Foundation for Statistical Computing
 Platform: x86_64-pc-linux-gnu (64-bit)
-
-R is free software and comes with ABSOLUTELY NO WARRANTY.
-You are welcome to redistribute it under the terms of the
-GNU General Public License versions 2 or 3.
-For more information about these matters see
-https://www.gnu.org/licenses/.
 ```
 
 > **Note:** [See this page for additional instructions if you run into troubles while installing R](https://cloud.r-project.org/bin/linux/ubuntu/).
@@ -346,7 +340,7 @@ https://www.gnu.org/licenses/.
 
 ### RStudio
 
-Download the Ubuntu 22 Desktop version (not Pro) of RStudio from [https://posit.co/download/rstudio-desktop/](https://posit.co/download/rstudio-desktop/). Open the file and follow the installer instructions.
+Download the Ubuntu 24 Desktop version (not Pro) of RStudio from [https://posit.co/download/rstudio-desktop/](https://posit.co/download/rstudio-desktop/). Open the file and follow the installer instructions.
 
 > **Note:** If you select "open with" and try to open the file directly with the Ubuntu Software app instead of downloading it first, the software app might complain that the file is not supported.
 
@@ -394,8 +388,8 @@ Stan is the language we will be using later on in the program for Bayesian stati
 To install it open RStudio and install `rstan`
 
 ```R
-install.packages("StanHeaders", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
-install.packages("rstan", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
+install.packages("StanHeaders", repos = c("https://stan-dev.r-universe.dev", getOption("repos")))
+install.packages("rstan", repos = c("https://stan-dev.r-universe.dev", getOption("repos")))
 ```
 
 > **Note:** If you are asked to update packages during the installation via `devtools::install_github`, select the `None` option.
@@ -660,10 +654,10 @@ sudo su -c psql postgres
 ```
 
 The above should yield the prompt to change to what is shown below
-(the exact minor version does not matter as the major version is 14):
+(the exact minor version does not matter as the major version is 16):
 
 ```
-psql (14.9 (Ubuntu 14.9-0ubuntu0.22.04.1))
+psql (16.9 (Ubuntu 16.9-0ubuntu0.24.04.1))
 Type "help" for help.
 
 postgres=#
@@ -675,7 +669,7 @@ postgres=#
 
 You will use Docker to create reproducible, sharable and shippable computing environments for your analyses. For this you will need a Docker account. You can [sign up for a free one here](https://store.docker.com/signup?next=%2F%3Fref%3Dlogin).
 
-After signing-up, you also need to install Docker **CE** for Ubuntu. Install the stable version by following the installation instructions using the ["Install using the repository" methods found here](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository), including the subheadings "Set up the repository" and "Install Docker engine" (you can skip step 2 "Install a specific version of the docker engine" since we already got the latest from step 1).
+After signing-up, you also need to install Docker **CE** for Ubuntu. Install the stable version by following the installation instructions using the ["Install using the repository" methods found here](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository), including the subheadings "Set up the repository" and "Install the Docker packages".
 
 Next, [follow the Linux post installation steps here](https://docs.docker.com/engine/install/linux-postinstall/) so that you can run Docker without typing `sudo`
 (only the subheading "Managing docker as a non-root user").
@@ -835,31 +829,32 @@ R -q -e "as.data.frame(installed.packages()[,3])"  # For R packages
 Checking program and package versions...
 
 ## Operating system
-Operating System: Ubuntu 22.04.1 LTS
+Operating System: Ubuntu 24.04.1 LTS
 Architecture:     x86-64
-Kernel:           Linux 6.2.0-26-generic
+Kernel:           Linux 6.6.87.2-microsoft-standard-WSL2
 
 ## System programs
-OK        psql 14.9 (Ubuntu 14.9-0ubuntu0.22.04.1)
-OK        rstudio 2023.06.2+561
-OK        R 4.3.1 (2023-06-16) -- "Beagle Scouts"
-OK        python 3.11.4
-OK        conda 23
-OK        bash 5.1.16(1)-release (x86_64-pc-linux-gnu)
-OK        git 2.34.1
+OK        psql
+OK        rstudio 2025.05.1+513
+OK        R 4.5.1 (2025-06-13) -- "Great Square Root"
+OK        python 3.12.11
+OK        conda 25.7.0
+OK        bash 5.2.21(1)-release (x86_64-pc-linux-gnu)
+OK        git 2.43.0
 OK        make 4.3
-OK        latex 3.141592653-2.6-1.40.25 (TeX Live 2023)
-OK        tlmgr 5:21 +0200)
-OK        docker 24.0.5, build ced0996
-OK        code 1.81.1
+OK        latex 3.141592653-2.6-1.40.28 (TeX Live 2025)
+OK        tlmgr 5204 (2025-05-13 23:48:24 +0200)
+OK        docker 28.3.3, build 980b856
+OK        code 1.99.0
+OK        quarto 1.7.33
 
 ## Python packages
-OK        otter-grader=5.1.3
-OK        pandas=2.0.3
-OK        nbconvert-core=7.7.4
-OK        playwright=1.37.0
-OK        jupyterlab=4.0.5
-OK        jupyterlab-git=0.41.0
+OK        otter-grader=6.1.3
+OK        pandas=2.3.1
+OK        nbconvert-core=7.16.6
+OK        playwright=1.54.0
+OK        jupyterlab=4.4.5
+OK        jupyterlab-git=0.51.2
 OK        jupyterlab-spellchecker=0.8.4
 OK        jupyterlab PDF-generation was successful.
 OK        jupyterlab WebPDF-generation was successful.
@@ -867,22 +862,24 @@ OK        jupyterlab HTML-generation was successful.
 
 ## R packages
 OK        tidyverse=2.0.0
-OK        markdown=1.8
-OK        rmarkdown=2.24
-OK        renv=1.0.2
+OK        markdown=2.0
+markdown=2.29
+OK        rmarkdown=2.29
+OK        renv=1.1.5
 OK        IRkernel=1.3.2
-OK        tinytex=0.46
-OK        janitor=2.2.0
-OK        gapminder=1.0.0
-OK        readxl=1.4.3
-OK        ottr=1.1.3
+OK        tinytex=0.57
+OK        janitor=2.2.1
+OK        gapminder=1.0.1
+OK        readxl=1.4.5
+OK        ottr=1.5.2
 OK        canlang=0.0.1
 OK        rmarkdown PDF-generation was successful.
 OK        rmarkdown HTML-generation was successful.
 
-The above output has been saved to the file /home/vboxuser/check-setup-mds.log
+The above output has been saved to the file /home/user/check-setup-mds.log
 together with system configuration details and any detailed error messages about PDF and HTML generation.
 You can open this folder in your file browser by typing `xdg-open .` (without the surrounding backticks).
+Before sharing the log file, review that there is no SENSITIVE INFORMATION such as passwords or access tokens in it.
 ````
 
 As you can see at the end of the output,

--- a/resources_pages/install_ds_stack_ubuntu.md
+++ b/resources_pages/install_ds_stack_ubuntu.md
@@ -831,7 +831,7 @@ Checking program and package versions...
 ## Operating system
 Operating System: Ubuntu 24.04.1 LTS
 Architecture:     x86-64
-Kernel:           Linux 6.6.87.2-microsoft-standard-WSL2
+Kernel:           Linux 6.6.87.2
 
 ## System programs
 OK        psql

--- a/resources_pages/install_ds_stack_windows.md
+++ b/resources_pages/install_ds_stack_windows.md
@@ -60,7 +60,7 @@ In MDS we will be using many tools that work most reliably on Google Chrome and 
 
 ## Password manager
 
-A password manager is an efficient and convenient measure to protect your online accounts from most common threats. While you don't strictly need to use one for any of the courses in MDS, we **highly recommend** that you set one up for your own benefit. Examples of reliable password managers include the ones built into Chrome and Firefox, [Bitwarden](https://bitwarden.com/), and [KeePassXC](https://keepassxc.org/) (if you prefer to sync your passwords manually).
+A password manager is an efficient and convenient measure to protect your online accounts from most common threats. While you don't strictly need to use one for any of the courses in MDS, we **highly recommend** that you set one up for your own benefit. Examples of reliable password managers include the ones built into Chrome and Firefox, as well as [Bitwarden](https://bitwarden.com/), and [KeePassXC](https://keepassxc.org/) (if you prefer to sync your passwords manually).
 
 ## Slack
 
@@ -509,8 +509,8 @@ R --version
 which should return something like:
 
 ```R
-R version 4.2.1 (2022-06-23 ucrt) -- "Funny-Looking Kid"
-Copyright (C) 2022 The R Foundation for Statistical Computing
+R version 4.5.1 (2025-06-13) -- "Great Square Root"
+Copyright (C) 2025 The R Foundation for Statistical Computing
 Platform: x86_64-w64-mingw32/x64 (64-bit)
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
@@ -520,7 +520,7 @@ For more information about these matters see
 https://www.gnu.org/licenses/.
 ```
 
-> **Note**: Although it is possible to install R through Anaconda, we highly recommend not doing so. In case you have already installed R using Anaconda you can remove it by executing `conda uninstall r-base`.
+> **Note**: Although it is possible to install R through Miniforge3, we highly recommend not doing so. In case you have already installed R using Miniforge3 you can remove it by executing `conda uninstall r-base`.
 
 ### RStudio
 
@@ -607,8 +607,8 @@ Stan is the language we will be using later on in the program for Bayesian stati
 To install it open RStudio and install `rstan`
 
 ```R
-install.packages("StanHeaders", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
-install.packages("rstan", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
+install.packages("StanHeaders", repos = c("https://stan-dev.r-universe.dev", getOption("repos")))
+install.packages("rstan", repos = c("https://stan-dev.r-universe.dev", getOption("repos")))
 ```
 
 > **Note:** If you are asked to update packages during the installation via `devtools::install_github`, select the `None` option.
@@ -902,7 +902,7 @@ There is NO WARRANTY, to the extent permitted by law.
 
 ## PostgreSQL
 
-We will be using PostgreSQL as our database management system. You can download the most recent version of PostgreSQL from [here](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads). Follow the instructions for the installation. In the password page, type whatever password you want, **and make sure you save it using a password manager or similar so that you know what it is in November when the SQL course starts** (otherwise you will need to reinstall PostgreSQL). For all the other options, use the default. You do not need to run "StackBuilder" at the end of the installation (if you accidentally launch the StackBuilder, click "cancel", you don't need to check any boxes).
+We will be using PostgreSQL as our database management system. You can download PostgreSQL 16.10 from [here](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads). Follow the instructions for the installation. In the password page, type whatever password you want, **and make sure you save it using a password manager or similar so that you know what it is in November when the SQL course starts** (otherwise you will need to reinstall PostgreSQL). For all the other options, use the default. You do not need to run "StackBuilder" at the end of the installation (if you accidentally launch the StackBuilder, click "cancel", you don't need to check any boxes).
 
 To test if the installation was successful open the `SQL Shell` app from the Start menu. You will be asked to setup your configuration, accept the default value (the one within square brackets) for the first four values by pressing enter four times, then type in your password and press enter one last time. It should look like this if it is working correctly:
 
@@ -1113,12 +1113,11 @@ Microsoft Windows 11 Pro
 MISSING You need Windows 10 or 11 with build number >= 10.0.19041. Please run Windows update.
 
 ## System programs
-OK        psql (PostgreSQL) 15.4
- 2023.06.2+561dio
+OK        psql (PostgreSQL) 16.9
 OK        tlmgr revision 66798 (2023-04-08 02:15:21 +0200)
-OK        R 4.3.1 (2023-06-16 ucrt) -- "Beagle Scouts"
-OK        python 3.11.4
-OK        conda 23
+OK        R 4.5.1 (2025-06-13) -- "Great Square Root"
+OK        python 3.12.11
+OK        conda 25
 OK        bash 4-pc-msys)
 OK        git 2.42.0.windows.1
 OK        make 4.4.1


### PR DESCRIPTION
- made sure mac mx/apple silicon is mentioned first by default, added aliases they can encounter in package installation (Apple Silicon, Mac M1-M4, Mac arm64 or Darwin)
- updated versions in example outputs for easier matching
- added note that the script with Miniforge installer will have platform in its name
- updated Stan repos: stan switched to r-universe.dev, old repo is not supported anymore (checked with @alexrod61)
- Added ref to PostgreSQL 16.10 to macos instructions as this is the version to be fetched by ubuntu 24.04 lts (checked with @ggeorg02)
- Corrected docker for ubuntu install instructions to reflect small changes in their download webpage