### PR TITLE
Update macOS version check in setup script

### DIFF
--- a/resources_pages/check-setup-mds.sh
+++ b/resources_pages/check-setup-mds.sh
@@ -43,7 +43,7 @@ if [[ "$(uname)" == 'Linux' ]]; then
 elif [[ "$(uname)" == 'Darwin' ]]; then
     sw_vers >> check-setup-mds.log
     file_browser="open"
-    if ! $(sw_vers | grep -iq "14.\|13.\|12.\|11.[4|5|6]"); then
+    if ! $(sw_vers | grep -iq "15.\|14.\|13.\|12.\|11.[4|5|6]"); then
         echo '' >> check-setup-mds.log
         echo "MISSING You need macOS Big Sur or greater (>=11.4)." >> check-setup-mds.log
     fi


### PR DESCRIPTION
There is a new macOS version (15) which should be accepted too. I just helped a student that ran into this.

The more appropriate way to check this in the future is to parse it as a number.